### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/maximilian2304/975a9804-a42a-4b42-b259-72c2d414059b/0f1ae8aa-2fed-43b2-bd11-7d858c3d07c1/_apis/work/boardbadge/5e472fe8-0999-4580-8ee7-093fa71da0ee)](https://dev.azure.com/maximilian2304/975a9804-a42a-4b42-b259-72c2d414059b/_boards/board/t/0f1ae8aa-2fed-43b2-bd11-7d858c3d07c1/Microsoft.RequirementCategory)
 # SmartHub


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/maximilian2304/975a9804-a42a-4b42-b259-72c2d414059b/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.