### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,2 @@
+[![Board Status](https://dev.azure.com/SmartHub-Studio/58c1ce45-66da-4da5-92ef-f13f0440b4ac/ba9e3931-c970-4b04-a79f-c13b5108cdca/_apis/work/boardbadge/f0a131d6-c38c-4750-ba91-7d15ea261df1)](https://dev.azure.com/SmartHub-Studio/58c1ce45-66da-4da5-92ef-f13f0440b4ac/_boards/board/t/ba9e3931-c970-4b04-a79f-c13b5108cdca/Microsoft.RequirementCategory)
 # SmartHub


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/SmartHub-Studio/58c1ce45-66da-4da5-92ef-f13f0440b4ac/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.